### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ numpy==1.24.1
 omegaconf==2.3.0
 open_clip_torch==2.16.0
 opencv_python==4.7.0.72
+opencv-contrib-python==4.7.0.72
 Pillow==9.4.0
 pytorch_lightning==1.5.0
 prettytable==3.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ moviepy==1.0.3
 numpy==1.24.1
 omegaconf==2.3.0
 open_clip_torch==2.16.0
-opencv_python==4.7.0.68
+opencv_python==4.7.0.72
 Pillow==9.4.0
 pytorch_lightning==1.5.0
 prettytable==3.6.0


### PR DESCRIPTION
fixes Collecting opencv_python==4.7.0.68
  Using cached opencv_python-4.7.0.68-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (61.8 MB)
ERROR: Could not find a version that satisfies the requirement opencv-contrib-python==4.3.0.36 (from versions: 3.4.11.45, 3.4.13.47, 3.4.14.51, 3.4.15.55, 3.4.16.59, 3.4.17.61, 3.4.17.63, 3.4.18.65, 4.4.0.46, 4.5.1.48, 4.5.2.52, 4.5.3.56, 4.5.4.58, 4.5.4.60, 4.5.5.62, 4.5.5.64, 4.6.0.66, 4.7.0.68, 4.7.0.72) ERROR: No matching distribution found for opencv-contrib-python==4.3.0.36